### PR TITLE
Updated config for BESSY after archiver moved in network.

### DIFF
--- a/bact_archiver_bessyii/archiver.cfg
+++ b/bact_archiver_bessyii/archiver.cfg
@@ -3,11 +3,11 @@ name = BESSY
 
 [BESSY]
 description = central BESSY archiver
-base_url = http://archiver.bessy.de
+base_url = https://archiver.bessy.de
 
 [AAPL]
 description = central BESSY archiver
-base_url = http://archiver.bessy.de
+base_url = https://archiver.bessy.de
 
 [FASTZC]
 description = "Fast Short Term Archiver inside BESSY Control System",

--- a/bact_archiver_bessyii/archiver.cfg
+++ b/bact_archiver_bessyii/archiver.cfg
@@ -3,11 +3,11 @@ name = BESSY
 
 [BESSY]
 description = central BESSY archiver
-base_url = http://archiver.trs.bessy.de
+base_url = http://archiver.bessy.de
 
 [AAPL]
 description = central BESSY archiver
-base_url = http://archiver.trs.bessy.de
+base_url = http://archiver.bessy.de
 
 [FASTZC]
 description = "Fast Short Term Archiver inside BESSY Control System",


### PR DESCRIPTION
The BESSY archiver was moved in the network so an update is needed to the config file.